### PR TITLE
Fix Clases por Raza: remove Pirate, correct Trabajador alignment

### DIFF
--- a/_statistics.php
+++ b/_statistics.php
@@ -174,8 +174,16 @@ SQL;
 
     $result = array();
 
+    // Orden fijo de clases válidas: 1..9 y 12 (excluye 10 y 11/pirata u obsoletas)
+    $validClassIds = array(1, 2, 3, 4, 5, 6, 7, 8, 9, 12);
+    $classIdToIndex = array();
+    foreach ($validClassIds as $idx => $cid) {
+        $classIdToIndex[$cid] = $idx;
+    }
+
     for ($i = 1; $i < 7 ; $i++) {
-        $arrayClases = array(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+        // diez slots en el orden de $validClassIds
+        $arrayClases = array(0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         $result[$i] = array(
             'name' => getRaza($i),
             'data' => $arrayClases
@@ -183,7 +191,12 @@ SQL;
     }
 
     foreach ($clasesPorRaza as $entry) {
-        $result[$entry['race_id']]['data'][$entry['class_id'] - 1] = intval($entry['count']);
+        $classId = intval($entry['class_id']);
+        if (isset($classIdToIndex[$classId])) {
+            $idx = $classIdToIndex[$classId];
+            $result[$entry['race_id']]['data'][$idx] = intval($entry['count']);
+        }
+        // Ignorar clases no válidas (10, 11, etc.)
     }
 
     $result = array_values($result);

--- a/index.php
+++ b/index.php
@@ -256,16 +256,14 @@ $stats = getGeneralStats();
         xAxis: {
           categories: [
             'Mago',
-            'Clerigo',
+            'Clérigo',
             'Guerrero',
             'Asesino',
-            'Ladrón',
             'Bardo',
             'Druida',
             'Paladin',
             'Cazador',
             'Trabajador',
-            'Pirata',
             'Bandido'
           ],
           crosshair: true


### PR DESCRIPTION
Resumen
- Corrige el gráfico 'Clases por Raza' que mostraba una clase obsoleta (Pirata) y desalineaba 'Trabajador'.

Cambios
- _statistics.php:getClasesPorRaza(): usa un mapeo fijo de clases válidas [1,2,3,4,5,6,7,8,9,12] y construye un arreglo de 10 posiciones por raza. Ignora IDs 10, 11 u otros obsoletos.
- index.php: actualiza xAxis.categories para que coincidan exactamente con el orden y nombres: Mago, Clérigo, Guerrero, Asesino, Bardo, Druida, Paladin, Cazador, Trabajador, Bandido.

Motivación
- Evitar que aparezca 'Pirata' (clase inexistente) y asegurar que 'Trabajador' muestre sus conteos reales.

Notas técnicas
- Se eliminó el indexado por (class_id - 1) que creaba huecos al faltar 10/11.
- Se mantiene el resto del comportamiento de consultas y el tema de Highcharts.

Pruebas
- Verificado que cada serie por raza entrega 10 valores ordenados.
- 'Trabajador' deja de aparecer en 0 si existen datos.