### PR TITLE
Fix kills per class: whitelist valid classes, restore HAVING > 0, map Bandido=12

### DIFF
--- a/_statistics.php
+++ b/_statistics.php
@@ -92,9 +92,6 @@ function getClase($classId) {
         case 9:
             $clase = 'Trabajador';
             break;
-        case 10:
-            $clase = 'Bandido';
-            break;
         case 12:
             $clase = 'Bandido';
             break;

--- a/_statistics.php
+++ b/_statistics.php
@@ -95,6 +95,9 @@ function getClase($classId) {
         case 10:
             $clase = 'Bandido';
             break;
+        case 12:
+            $clase = 'Bandido';
+            break;
         default:
             $clase = 'Otra';
             break;
@@ -224,8 +227,9 @@ function getKillsPorClase()
         FROM user
         WHERE deleted = FALSE
             AND guild_index <> 1
+            AND class_id IN (1,2,3,4,5,6,7,8,9,12)
         GROUP BY class_id
-        HAVING promedio_matados >= 1
+        HAVING promedio_matados > 0
         ORDER BY AVG(ciudadanos_matados + criminales_matados) DESC;
 SQL;
 


### PR DESCRIPTION
**Resumen**

Corrige el gráfico “Promedio de usuarios matados por clase” que mostraba “Otra” y omitía “Trabajador” (9) y “Bandido” (12).

**Problema**

“Otra” aparecía por filas con class_id no mapeados cayendo en el default.
“Bandido” no se mostraba por mapeo incorrecto y falta de control de IDs válidos.

**Cambios**

_statistics.php

getClase($classId): mapea Bandido solamente a class_id = 12

getKillsPorClase():
Restringe a IDs válidos: class_id IN (1,2,3,4,5,6,7,8,9,12) para evitar “Otra”.
Cambia el filtro de agregación: HAVING promedio_matados > 0.

**Impacto**

Desaparece “Otra” del gráfico de kills por clase.
“Trabajador” y “Bandido” aparecen cuando existan datos (> 0 de promedio).