### PR TITLE
 Fix: “Usuarios por nivel” chart not rendering data

### DIFF
--- a/_statistics.php
+++ b/_statistics.php
@@ -198,20 +198,29 @@ function getUsuariosPorLevel()
         FROM user
         WHERE deleted = false
             AND guild_index <> 1
+            AND level > 14
         GROUP BY level
         ORDER BY level ASC;
 SQL;
 
     $usuariosPorLevel = executeGetMultipleRowsQuery($query);
 
-    $result = array();
-
-    for ($i = 14; $i <= 54 ; $i++) {
-        $result[] = 0;
-    }
+    $levelToCount = array();
+    $maxLevel = 14;
 
     foreach ($usuariosPorLevel as $entry) {
-        $result[$entry['level'] - 14] = intval($entry['count']);
+        $level = intval($entry['level']);
+        $count = intval($entry['count']);
+        $levelToCount[$level] = $count;
+        if ($level > $maxLevel) {
+            $maxLevel = $level;
+        }
+    }
+
+    $result = array();
+    // Build a dense array starting at level 14 (index 0) to keep pointStart alignment
+    for ($level = 14; $level <= $maxLevel; $level++) {
+        $result[] = isset($levelToCount[$level]) ? $levelToCount[$level] : 0;
     }
 
     return $result;


### PR DESCRIPTION
Summary

Problem: “Usuarios por nivel” chart showed no data due to sparse/out-of-range series indexes.

Fix:

Built a dense series from level 14 to the maximum level in results, filling missing levels with 0 to align with pointStart: 14.

Files changed

/_statistics.php:

Updated getUsuariosPorLevel() SQL and result building logic.
